### PR TITLE
Oppdater endepunkter for henting av sykmelding, søknad, forespørsel og inntektsmelding

### DIFF
--- a/kataloger/tigersys/collection.bru
+++ b/kataloger/tigersys/collection.bru
@@ -1,3 +1,3 @@
 vars:pre-request {
-  tigersyskundeOrgnr: 311368095
+  tigersyskundeOrgnr: 314127161
 }

--- a/kataloger/tigersys/hent inntektsmeldinger.bru
+++ b/kataloger/tigersys/hent inntektsmeldinger.bru
@@ -1,5 +1,5 @@
 meta {
-  name: inntektsmeldinger filter
+  name: hent inntektsmeldinger
   type: http
   seq: 6
 }
@@ -16,8 +16,13 @@ auth:bearer {
 
 body:json {
   {
-    "tom": "2025-06-04",
-    "fom": "2025-06-04"
+    "orgnr": "315912784",
+    "innsendingId": null,
+    "fnr": null,
+    "navReferanseId": null,
+    "tom": null,
+    "fom": null,
+    "status": null
   }
 }
 

--- a/kataloger/tigersys/hent sykepengesøknader.bru
+++ b/kataloger/tigersys/hent sykepengesøknader.bru
@@ -1,11 +1,11 @@
 meta {
-  name: sykmeldinger filter
+  name: hent sykepengesøknader
   type: http
-  seq: 18
+  seq: 22
 }
 
 post {
-  url: https://sykepenger-api.ekstern.dev.nav.no/v1/sykmeldinger
+  url: https://sykepenger-api.ekstern.dev.nav.no/v1/sykepengesoeknader
   body: json
   auth: bearer
 }
@@ -16,8 +16,10 @@ auth:bearer {
 
 body:json {
   {
-    "fnr": "14498527206",
-    "fom": "2025-05-23"
+    "orgnr": "315912784",
+    "fnr": null,
+    "tom": null,
+    "fom": null
   }
 }
 

--- a/kataloger/tigersys/hent sykmeldinger.bru
+++ b/kataloger/tigersys/hent sykmeldinger.bru
@@ -1,29 +1,31 @@
 meta {
-  name: hent forespørsler
+  name: hent sykmeldinger
   type: http
-  seq: 7
+  seq: 18
 }
 
 post {
-  url: https://sykepenger-api.ekstern.dev.nav.no/v1/forespoersler
+  url: https://sykepenger-api.ekstern.dev.nav.no/v1/sykmeldinger
   body: json
-  auth: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: 
 }
 
 body:json {
   {
     "orgnr": "315912784",
     "fnr": null,
-    "navReferanseId": null,
     "tom": null,
-    "fom": null,
-    "status": null
+    "fom": null
   }
 }
 
 script:pre-request {
   const http = require('axios');
-  let response = await http.post(
+  const response = await http.post(
     'https://hag-lps-api-client.ekstern.dev.nav.no/systembruker',
     'orgnr=' + bru.getCollectionVar("tigersyskundeOrgnr")
   )

--- a/kataloger/tigersys/send inn inntektsmelding.bru
+++ b/kataloger/tigersys/send inn inntektsmelding.bru
@@ -12,30 +12,30 @@ post {
 
 body:json {
   {
-    "navReferanseId": "0dd58a63-3cf4-47fc-a843-5f5d75230a29",
+    "navReferanseId": "a35dfec7-d4af-4d4c-b3f0-79aab9bd1a71",
     "agp": {
       "perioder": [
         {
-          "fom": "2024-12-01",
-          "tom": "2024-12-15"
+          "fom": "2024-04-16",
+          "tom": "2024-05-01"
         }
       ],
       "egenmeldinger": [
         {
-          "fom": "2024-11-30",
-          "tom": "2024-11-30"
+          "fom": "2024-04-15",
+          "tom": "2024-04-15"
         }
       ],
       "redusertLoennIAgp": null
     },
     "inntekt": {
       "beloep": 30047.0,
-      "inntektsdato": "2024-11-30",
+      "inntektsdato": "2024-04-16",
       "naturalytelser": [],
       "endringAarsaker": []
     },
     "refusjon": null,
-    "sykmeldtFnr": "26517630593",
+    "sykmeldtFnr": "03448223352",
     "arbeidsgiverTlf": "12345678",
     "aarsakInnsending": "Endring",
     "avsender": {
@@ -51,6 +51,6 @@ script:pre-request {
     'https://hag-lps-api-client.ekstern.dev.nav.no/systembruker',
     'orgnr=' + bru.getCollectionVar("tigersyskundeOrgnr")
   )
-
+  
   req.setHeader('Authorization', "Bearer "+ response.data.tokenResponse.access_token);
 }


### PR DESCRIPTION
1. Rename til `hent sykmelding`, `hent sykepengesøknad`, `hent forespørsel` og `hent inntektsmelding`.
2. Oppdater til en testbedrift der systembruker er registrert på hovedenhet. Hovedenhet `314127161` og underenhet `315912784`.
3. Legg til alle felter i filteret (også de som man ikke velger å filtrere på, som vi setter til null).

Neste PR: Fjerner de GET-endepunktene som vi faser ut.