### PR TITLE
Legg til alternativ måte å kjøre på i README (med prosjektets gradleversjon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Start ULV:
 ```bash
 gradle run
 ```
+alternativt
+```bash
+./gradlew run
+```
 
 Test med CURL ved å lese dialog i Altinn 3 med id `0194bc95-97b4-7240-961f-9663743d4518` og token for `sykepenger-im-lps-api`
 ```bash


### PR DESCRIPTION
**Bakgrunn**
Fikk denne feilen på oppstart med `gradle run`, som viste seg å skyldes for _ny_ Gradle versjon lokalt.
```
> Failed to apply plugin class 'com.github.jengelman.gradle.plugins.shadow.ShadowApplicationPlugin'.
```

**Løsning**
For at ikke flere skal gå i garnet og kaste bort tid på å debugge dette, så tuner jeg litt på README-fila.